### PR TITLE
Able to use `robot.send room: "some/roomUri", ...` as other adapters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ build/Release
 # Deployed apps should consider commenting this line out:
 # see https://npmjs.org/doc/faq.html#Should-I-check-my-node_modules-folder-into-git
 node_modules
+
+# IDEs
+.idea

--- a/src/adapter.coffee
+++ b/src/adapter.coffee
@@ -50,7 +50,7 @@ class Gitter extends Adapter
           # When the adapter wants to send message to this room
           @on 'gitter:send:'+room.id, (envelope, strings) ->
             strings.forEach (text) ->
-              room.send text
+              room.send text if text? and text isnt ''
             undefined
         )
         .fail((err) ->


### PR DESCRIPTION
This PR is first a new feature, but includes also a fix:
- [x] Fixes an error where the bot will stop sending messages and respond to them as soon as he'd send an empty message
  
  This might be fixing #3 as I couldn't reproduce but I am not sure at all
- [x] Using `robot.send {room: 'user/repo'}, 'hello'` is now working (for joined rooms of course).
  
  No need to know the room ID
  
  This works also with the URI to a channel
